### PR TITLE
Mgrs::fromGridReference isn't returning correct results

### DIFF
--- a/src/Mgrs/Mgrs.php
+++ b/src/Mgrs/Mgrs.php
@@ -474,10 +474,10 @@ class Mgrs extends Utm {
         // Return a new Mgrs object.
 
         $mgrs = new static(
-            $easting,
             $northing,
-            $zone_letter,
-            $zone_number
+            $easting,
+            $zone_number,
+            $zone_letter
         );
 
         // Set the accuracy according to the number of digits found.


### PR DESCRIPTION
Returned Mgrs object attributes are in wrong order
