### PR TITLE
#5

### DIFF
--- a/src/Mgrs/Mgrs.php
+++ b/src/Mgrs/Mgrs.php
@@ -286,7 +286,7 @@ class Mgrs extends Utm {
      *        1-60.
      * @return two letter MGRS 100k code.
      */
-    protected function getLetter100kId($column, $row, $parm) {
+    protected static function getLetter100kId($column, $row, $parm) {
         // colOrigin and rowOrigin are the letters at the origin of the set
         $index = $parm - 1;
         $colOrigin = ord(substr(static::SET_ORIGIN_COLUMN_LETTERS, $index, 1));


### PR DESCRIPTION
Fix for php 7.1
Calling Mgrs :: forward results in an error in Laravel:
Academic \ Proj4Php \ Mgrs \ Mgrs :: getLetter100kId () should not be called \ academe \ proj4php \ src \ Mgrs \ Mgrs.php at the line # 253